### PR TITLE
disable NotificationView

### DIFF
--- a/lib/js_refactor.coffee
+++ b/lib/js_refactor.coffee
@@ -1,5 +1,5 @@
 Ripper = require './ripper'
-NotificationView = require './notification_view'
+#NotificationView = require './notification_view'
 
 { packages: packageManager } = atom
 
@@ -7,7 +7,7 @@ module.exports =
   activate: ->
     return if 'refactor' in packageManager.getAvailablePackageNames() and
               !packageManager.isPackageDisabled 'refactor'
-    new NotificationView
+    #new NotificationView
   deactivate: ->
   serialize: ->
   Ripper: Ripper


### PR DESCRIPTION
NotificationView depends on old APIs which has been removed in latest atom core.

This pull request is just a workaround which disable NotificationView to make js-refactor work.
